### PR TITLE
feat: interactive config editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.4.6] - 2025-08-09
+
+### Added
+- add interactive configuration editor and temporary in-memory adjustments

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
-- [ ] implement an interactive editor for the configuration
+- [x] implement an interactive editor for the configuration
   - tree-view of files
   - ability to check and uncheck files and directories for inclusion in tree and for inclusion of full text
-- [ ] implement mode to make modifications to the config, but temporarily, only for one execution. When the command is run, the interactive file selector should pop up, the user can select and deselect files, and then when they are done, it should run with those modified settings, but not modify the config file
+- [x] implement mode to make modifications to the config, but temporarily, only for one execution. When the command is run, the interactive file selector should pop up, the user can select and deselect files, and then when they are done, it should run with those modified settings, but not modify the config file
  - [x] switch to toml format for config file
  - [x] allow configuration inside pyproject.toml (`[tool.grobl]`)
  - [x] improve the formatting/presentation of information in the clipboard copied content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "grobl"
-  version = "0.4.5"
+  version = "0.4.6"
   description = "A script to display directory structure and Python file contents"
   readme = "README.md"
   authors = [

--- a/src/grobl/editor.py
+++ b/src/grobl/editor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import tomlkit
+
+from .config import TOML_CONFIG
+from .directory import traverse_dir
+from .utils import find_common_ancestor
+
+
+def _build_tree(paths: list[Path], base: Path) -> tuple[list[str], dict[str, Path]]:
+    """Return tree lines and an index→relative-path mapping."""
+    lines: list[str] = []
+    mapping: dict[str, Path] = {}
+
+    def collect(item: Path, prefix: str, *, is_last: bool) -> None:
+        connector = "└── " if is_last else "├── "
+        rel = item.relative_to(base)
+        lines.append(f"{prefix}{connector}{item.name}")
+        mapping[str(len(lines))] = rel
+
+    traverse_dir(base, (paths, [], base), collect)
+    lines.insert(0, base.name)
+    return lines, mapping
+
+
+def _prompt_indices(
+    prompt: str, *, input_iter: Iterator[str] | None = None
+) -> list[str]:
+    """Prompt the user and return a list of indices."""
+    if input_iter is None:
+        response = input(prompt).strip()
+    else:
+        try:
+            response = next(input_iter).strip()
+        except StopIteration:
+            response = ""
+    if not response:
+        return []
+    return response.split()
+
+
+def interactive_edit_config(
+    paths: list[Path], cfg: dict, *, save: bool, input_iter: Iterator[str] | None = None
+) -> dict:
+    """Interactively edit configuration.
+
+    Parameters
+    ----------
+    paths:
+        Paths to include in the tree view.
+    cfg:
+        Existing configuration dictionary to modify.
+    save:
+        If true, write the updated configuration to ``TOML_CONFIG``.
+    input_iter:
+        Optional iterator for providing input programmatically (used in tests).
+    """
+
+    resolved = [p.resolve() for p in paths]
+    base = find_common_ancestor(resolved)
+    lines, mapping = _build_tree(resolved, base)
+
+    print("\n".join(lines))
+
+    excl_tree = set(cfg.get("exclude_tree", []))
+    tree_indices = _prompt_indices(
+        "Enter numbers to toggle exclusion from tree (blank to continue): ",
+        input_iter=input_iter,
+    )
+    for idx in tree_indices:
+        rel = mapping.get(idx)
+        if rel is None:
+            continue
+        rel_str = str(rel)
+        if rel_str in excl_tree:
+            excl_tree.remove(rel_str)
+        else:
+            excl_tree.add(rel_str)
+    cfg["exclude_tree"] = sorted(excl_tree)
+
+    excl_print = set(cfg.get("exclude_print", []))
+    print_indices = _prompt_indices(
+        "Enter numbers to toggle exclusion from file contents (blank to finish): ",
+        input_iter=input_iter,
+    )
+    for idx in print_indices:
+        rel = mapping.get(idx)
+        if rel is None:
+            continue
+        if (base / rel).is_dir():
+            continue
+        rel_str = str(rel)
+        if rel_str in excl_print:
+            excl_print.remove(rel_str)
+        else:
+            excl_print.add(rel_str)
+    cfg["exclude_print"] = sorted(excl_print)
+
+    if save:
+        toml_path = base / TOML_CONFIG
+        toml_path.write_text(tomlkit.dumps(cfg), encoding="utf-8")
+        print(f"Saved {TOML_CONFIG}")
+
+    return cfg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,7 +107,9 @@ def test_cli_migrate_config(monkeypatch, tmp_path):
 
     with pytest.raises(SystemExit) as e:
         main()
-    assert e.value.code == 0
+    exc = e.value
+    assert isinstance(exc, SystemExit)
+    assert exc.code == 0
 
 
 def test_binary_file_in_tree_without_content(tmp_path, mock_clipboard):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,9 @@ def test_cli_migrate_config(monkeypatch, tmp_path):
 
     with pytest.raises(SystemExit) as e:
         cli.main()
-    assert e.value.code == 0
+    exc = e.value
+    assert isinstance(exc, SystemExit)
+    assert exc.code == 0
 
 
 def test_load_json_config(tmp_path):
@@ -193,7 +195,9 @@ def test_cli_configloaderror(monkeypatch):
     # Now run it, expecting SystemExit
     with pytest.raises(SystemExit) as e:
         cli.main()
-    assert e.value.code == 1
+    exc = e.value
+    assert isinstance(exc, SystemExit)
+    assert exc.code == 1
 
 
 def test_read_config_handles_invalid_toml(monkeypatch, tmp_path):
@@ -207,4 +211,6 @@ def test_read_config_handles_invalid_toml(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc_info:
         cli.main()
 
-    assert exc_info.value.code == 1
+    exc = exc_info.value
+    assert isinstance(exc, SystemExit)
+    assert exc.code == 1

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+
+import tomllib
+
+from grobl.cli import main
+from grobl.editor import interactive_edit_config
+
+
+def test_interactive_edit_config_saves(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    inputs = iter(["1", "2"])
+    monkeypatch.setattr("builtins.input", lambda _=None: next(inputs))
+    cfg: dict = {}
+    interactive_edit_config([tmp_path], cfg, save=True)
+    data = tomllib.loads((tmp_path / ".grobl.config.toml").read_text(encoding="utf-8"))
+    assert "a.txt" in data["exclude_tree"]
+    assert "b.txt" in data["exclude_print"]
+
+
+def test_cli_interactive_run_excludes(tmp_path, monkeypatch, capsys):
+    (tmp_path / "keep.txt").write_text("k", encoding="utf-8")
+    (tmp_path / "skip.txt").write_text("s", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    inputs = iter(["2", ""])
+    monkeypatch.setattr("builtins.input", lambda _=None: next(inputs))
+    monkeypatch.setattr("grobl.cli.human_summary", lambda *_a, **_k: None)
+    monkeypatch.setattr(sys, "argv", ["grobl", "--no-clipboard", "--interactive"])
+    main()
+    out = capsys.readouterr().out
+    tree_section = out.split("<tree root=")[-1]
+    assert "keep.txt" in tree_section
+    assert "skip.txt" not in tree_section
+    assert not (tmp_path / ".grobl.config.toml").exists()


### PR DESCRIPTION
## Summary
- add interactive configuration editor with file tree selection
- support temporary in-memory ignore adjustments via --interactive
- document changes in changelog and bump version to 0.4.6

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b376b330832788d5c9576d369f74