### PR TITLE
feat: add optional token counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.7] - 2025-08-09
+
+### Added
+- add optional token counting with `--tokens` flag
+
 ## [0.4.6] - 2025-08-09
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -4,45 +4,45 @@ Add optional token counting to `grobl` using `tiktoken` (or `cntkn` wrapper).
 
 ## Core Implementation
 
-- [ ] **Add CLI flags**
-  - [ ] `--tokens` → enable token counting and show in summary.
-  - [ ] `--tokenizer <name>` → choose tokenizer (default: `cl100k_base`).
-  - [ ] `--tokens-for printed|all` → choose which files get counted.
-  - [ ] `--budget <n>` → display prompt budget usage (% of total).
-  - [ ] Print chosen tokenizer in Project Summary header.
+- [x] **Add CLI flags**
+  - [x] `--tokens` → enable token counting and show in summary.
+  - [x] `--tokenizer <name>` → choose tokenizer (default: `cl100k_base`).
+  - [x] `--tokens-for printed|all` → choose which files get counted.
+  - [x] `--budget <n>` → display prompt budget usage (% of total).
+  - [x] Print chosen tokenizer in Project Summary header.
 
-- [ ] **Make dependency optional**
-  - [ ] Add `tiktoken` (or `cntkn`) under an extra in `pyproject.toml` (`tokens` extra).
-  - [ ] Lazy import in code; fail gracefully if missing.
+- [x] **Make dependency optional**
+  - [x] Add `tiktoken` (or `cntkn`) under an extra in `pyproject.toml` (`tokens` extra).
+  - [x] Lazy import in code; fail gracefully if missing.
 
-- [ ] **Integrate into pipeline**
-  - [ ] After `read_text(...)`, compute token count for text files.
-  - [ ] Skip counting for binary files and excluded-from-print files (configurable).
-  - [ ] Store tokens in `DirectoryTreeBuilder` along with lines/chars.
-  - [ ] Track `total_tokens`.
+- [x] **Integrate into pipeline**
+  - [x] After `read_text(...)`, compute token count for text files.
+  - [x] Skip counting for binary files and excluded-from-print files (configurable).
+  - [x] Store tokens in `DirectoryTreeBuilder` along with lines/chars.
+  - [x] Track `total_tokens`.
 
-- [ ] **Update output**
-  - [ ] Add Tokens column to `human_summary(...)` table if present.
-  - [ ] Optionally add `tokens="N"` attribute in `<file:content>` tags.
-  - [ ] Show total tokens in summary footer.
+- [x] **Update output**
+  - [x] Add Tokens column to `human_summary(...)` table if present.
+  - [x] Optionally add `tokens="N"` attribute in `<file:content>` tags.
+  - [x] Show total tokens in summary footer.
 
 
 ## Performance & Safety
 
-- [ ] **Optimize counting**
-  - [ ] Cache counts keyed by `(path, size, mtime)`.
-  - [ ] Warn or skip tokenization for very large files unless `--force-tokens`.
-  - [ ] Store token counts in `.grobl.tokens.json` cache for faster repeat runs.
+- [x] **Optimize counting**
+  - [x] Cache counts keyed by `(path, size, mtime)`.
+  - [x] Warn or skip tokenization for very large files unless `--force-tokens`.
+  - [x] Store token counts in `.grobl.tokens.json` cache for faster repeat runs.
 
-- [ ] **Error handling**
-  - [ ] If `--tokens` used but no tokenizer found, print friendly error and exit non-zero.
+- [x] **Error handling**
+  - [x] If `--tokens` used but no tokenizer found, print friendly error and exit non-zero.
 
 ## Testing
 
-- [ ] Unit tests:
-  - [ ] Mock token counter → assert correct column, per-file counts, and totals.
-- [ ] CLI tests:
-  - [ ] Run with `--tokens` and monkeypatched counter; check summary output.
-  - [ ] Run with `--tokens` without tokenizer installed → expect clear error.
-- [ ] Performance tests:
-  - [ ] Ensure large directories don’t become unusably slow with token counting.
+- [x] Unit tests:
+  - [x] Mock token counter → assert correct column, per-file counts, and totals.
+- [x] CLI tests:
+  - [x] Run with `--tokens` and monkeypatched counter; check summary output.
+  - [x] Run with `--tokens` without tokenizer installed → expect clear error.
+- [x] Performance tests:
+  - [x] Ensure large directories don’t become unusably slow with token counting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "grobl"
-  version = "0.4.6"
+  version = "0.4.7"
   description = "A script to display directory structure and Python file contents"
   readme = "README.md"
   authors = [
@@ -20,6 +20,9 @@
     "pyperclip",
     "tomlkit>=0.13.2",
   ]
+
+  [project.optional-dependencies]
+    tokens = ["tiktoken"] # optional dependency for token counting
 
   [project.scripts]
     grobl = "grobl.cli:main"

--- a/src/grobl/formatter.py
+++ b/src/grobl/formatter.py
@@ -7,9 +7,19 @@ def escape_markdown(text: str) -> str:
     return re.sub(markdown_chars, r"\\\1", text)
 
 
-def human_summary(tree_lines: list[str], total_lines: int, total_chars: int) -> None:
+def human_summary(
+    tree_lines: list[str],
+    total_lines: int,
+    total_chars: int,
+    *,
+    total_tokens: int | None = None,
+    tokenizer: str | None = None,
+    budget: int | None = None,
+) -> None:
     max_width = max(len(line) for line in tree_lines)
     title = " Project Summary "
+    if tokenizer:
+        title = f" Project Summary ({tokenizer}) "
     bar = "═" * ((max_width - len(title)) // 2)
     print(f"{bar}{title}{bar}")
     for line in tree_lines:
@@ -17,4 +27,10 @@ def human_summary(tree_lines: list[str], total_lines: int, total_chars: int) -> 
     print("─" * max_width)
     print(f"Total lines: {total_lines}")
     print(f"Total characters: {total_chars}")
+    if total_tokens is not None:
+        line = f"Total tokens: {total_tokens}"
+        if budget:
+            pct = total_tokens / budget if budget else 0
+            line += f" ({pct:.0%} of budget)"
+        print(line)
     print("═" * max_width)

--- a/src/grobl/tokens.py
+++ b/src/grobl/tokens.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+TOKEN_LIMIT_BYTES = 1_000_000
+
+
+class TokenizerNotAvailableError(RuntimeError):
+    """Raised when the tokenization dependency is not installed."""
+
+
+def load_tokenizer(name: str) -> Callable[[str], int]:
+    """Return a function that counts tokens for the given tokenizer name."""
+    try:
+        import tiktoken  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise TokenizerNotAvailableError(
+            "Token counting requires 'tiktoken'. Install with 'pip install grobl[tokens]'"
+        ) from exc
+    enc = tiktoken.get_encoding(name)
+    return lambda text: len(enc.encode(text))
+
+
+def load_cache(path: Path) -> dict[str, dict[str, int]]:
+    """Load the token cache from disk."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def save_cache(cache: dict[str, dict[str, int]], path: Path) -> None:
+    """Persist the token cache to disk."""
+    try:
+        path.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def count_tokens(
+    text: str,
+    file_path: Path,
+    tokenizer: Callable[[str], int],
+    cache: dict[str, dict[str, int]],
+    *,
+    force: bool,
+    warn: Callable[[str], None] = print,
+) -> int:
+    """Count tokens for ``text`` using ``tokenizer`` with caching."""
+    stat = file_path.stat()
+    key = str(file_path)
+    size = stat.st_size
+    mtime = int(stat.st_mtime)
+    entry = cache.get(key)
+    if (
+        entry
+        and entry.get("size") == size
+        and entry.get("mtime") == mtime
+        and not force
+    ):
+        return entry["tokens"]
+    if not force and size > TOKEN_LIMIT_BYTES:
+        warn(
+            f"Skipping tokenization for {file_path} ({size} bytes). Use --force-tokens to override."
+        )
+        tokens = 0
+    else:
+        tokens = tokenizer(text)
+    cache[key] = {"size": size, "mtime": mtime, "tokens": tokens}
+    return tokens

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,8 +20,8 @@ def test_directory_tree_builder_adds_entries_and_files():
     # Test adding a file and metadata
     builder = DirectoryTreeBuilder(Path("/test"), [])
     builder.add_file_to_tree(Path("/test/file.txt"), "", is_last=True)
-    builder.record_metadata(Path("file.txt"), 5, 42)
-    builder.add_file(Path("/test/file.txt"), Path("file.txt"), 5, 42, "content")
+    builder.record_metadata(Path("file.txt"), 5, 42, 0)
+    builder.add_file(Path("/test/file.txt"), Path("file.txt"), 5, 42, 0, "content")
     assert (
         '<file:content name="file.txt" lines="5" chars="42">' in builder.file_contents
     )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -23,7 +23,7 @@ def test_add_md_file_escapes_backticks(tmp_path):
     builder = DirectoryTreeBuilder(tmp_path, [])
     rel = Path("example.md")
     builder.add_file(
-        tmp_path / "example.md", rel, 1, 10, "Some content with ``` backticks."
+        tmp_path / "example.md", rel, 1, 10, 0, "Some content with ``` backticks."
     )
     out = builder.build_file_contents()
     assert r"\`\`\`" in out

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,72 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from grobl.cli import main, process_paths
+from grobl.tokens import TokenizerNotAvailableError
+
+
+def test_cli_tokens_summary(monkeypatch, tmp_path):
+    (tmp_path / "file.txt").write_text("hello world", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "grobl.cli.load_tokenizer",
+        lambda name: (lambda text: len(text.split())),
+    )
+    captured: dict[str, object] = {}
+
+    def fake_summary(
+        lines, total_lines, total_chars, *, total_tokens, tokenizer, budget
+    ):
+        captured["lines"] = lines
+        captured["total_tokens"] = total_tokens
+        captured["tokenizer"] = tokenizer
+
+    monkeypatch.setattr("grobl.cli.human_summary", fake_summary)
+    monkeypatch.setattr(sys, "argv", ["grobl", "--no-clipboard", "--tokens"])
+    main()
+    header = captured["lines"][0]
+    assert "tokens" in header
+    assert captured["total_tokens"] == 2
+    assert captured["tokenizer"] == "cl100k_base"
+
+
+def test_cli_tokens_error(monkeypatch, tmp_path, capsys):
+    (tmp_path / "file.txt").write_text("hi", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "grobl.cli.load_tokenizer",
+        lambda name: (_ for _ in ()).throw(
+            TokenizerNotAvailableError(
+                "Token counting requires 'tiktoken'. Install with 'pip install grobl[tokens]'"
+            )
+        ),
+    )
+    monkeypatch.setattr(sys, "argv", ["grobl", "--tokens"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert isinstance(exc.value, SystemExit)
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "tiktoken" in err
+
+
+def test_skip_large_file_tokenization(monkeypatch, tmp_path, mock_clipboard):
+    big = tmp_path / "big.txt"
+    big.write_text("a" * 20, encoding="utf-8")
+    monkeypatch.setattr(
+        "grobl.cli.load_tokenizer", lambda name: (lambda text: len(text))
+    )
+    monkeypatch.setattr("grobl.tokens.TOKEN_LIMIT_BYTES", 10)
+    with patch("grobl.cli.print"):
+        builder = process_paths([tmp_path], {}, mock_clipboard, tokens=True)
+    assert builder.total_tokens == 0
+    cache_file = tmp_path / ".grobl.tokens.json"
+    if cache_file.exists():
+        cache_file.unlink()
+    with patch("grobl.cli.print"):
+        builder = process_paths(
+            [tmp_path], {}, mock_clipboard, tokens=True, force_tokens=True
+        )
+    assert builder.total_tokens == 20


### PR DESCRIPTION
## Summary
- add optional token counting with configurable tokenizer, budget, and large-file handling
- expose `--tokens` family of CLI flags and persist counts via `.grobl.tokens.json`
- document token support and bump version

## Testing
- `ruff check src/ tests/`
- `ty check src/ tests/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979e253cd483279db117ee4f1ff798