### PR TITLE
feat: load model specs and config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.10] - 2025-08-10
+
+### Added
+- add internal model specifications with tokenizers and budget tiers
+- allow configuring default CLI options
+
+### Removed
+- remove implicit support for .groblignore and .grobl.config.json
+
+### Fixed
+- fix summary table header alignment and wording
+
 ## [0.4.9] - 2025-08-09
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,14 @@
-- [ ] add an internal listing of models, correct tokenizers, and budgets by subscription tier
+- [x] add an internal listing of models, correct tokenizers, and budgets by subscription tier
   - example: {'model': 'gpt-5', 'tokenizer': 'o200k_base', 'budget': {'free': 16000, 'plus': 32000, 'pro': 128000}} except stored as a toml file
-- [ ] remove implicit support for .groblignore and .grobl.config.json files. If they exist, inform the user and tell them that the files will be migrated to toml, then migrate them
-- [ ] add the ability to set default values for these command line options in the config files
+- [x] remove implicit support for .groblignore and .grobl.config.json files. If they exist, inform the user and tell them that the files will be migrated to toml, then migrate them
+- [x] add the ability to set default values for these command line options in the config files
   - `--no-clipboard`
   - `--tokens`
   - `--model`
   - `--budget`
   - `--force-tokens`
   - `--verbose`
-- [ ] fix summary table header and alignment. It currently looks like this:
+- [x] fix summary table header and alignment. It currently looks like this:
 ```
 ═══════════════════ Project Summary (o200k_base) ═══════════════════
                                             lines chars tokens incl
@@ -25,4 +25,3 @@ bingbong
 ├── .gitignore                                  184  3536      0        *
 ├── .grobl.config.toml                           25   448    137
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "grobl"
-  version = "0.4.9"
+  version = "0.4.10"
   description = "A script to display directory structure and Python file contents"
   readme = "README.md"
   authors = [

--- a/src/grobl/directory.py
+++ b/src/grobl/directory.py
@@ -82,7 +82,8 @@ class DirectoryTreeBuilder:
         header = f"{'':{name_width - 1}}{'lines':>{line_width}} {'chars':>{char_width}}"
         if has_tokens:
             header += f" {'tokens':>{tok_width}}"
-        header += f" {'incl':>4}"
+        marker_width = max(len("included"), 8)
+        header += f" {'included':>{marker_width}}"
         output = [header, self.base_path.name]
         entry_map = dict(self.file_tree_entries)
 
@@ -94,7 +95,7 @@ class DirectoryTreeBuilder:
                 line = f"{text:<{name_width}} {ln:>{line_width}} {ch:>{char_width}}"
                 if has_tokens:
                     line += f" {tk:>{tok_width}}"
-                line += f" {marker:>4}"
+                line += f" {marker:>{marker_width}}"
                 output.append(line)
             else:
                 output.append(text)

--- a/src/grobl/resources/models.toml
+++ b/src/grobl/resources/models.toml
@@ -1,0 +1,35 @@
+[models."gpt-4o"]
+model = "gpt-4o"
+tokenizer = "o200k_base"
+[models."gpt-4o".budget]
+default = 128000
+free = 16000
+plus = 32000
+pro = 128000
+
+[models."gpt-4o-mini"]
+model = "gpt-4o-mini"
+tokenizer = "o200k_base"
+[models."gpt-4o-mini".budget]
+default = 64000
+free = 16000
+plus = 32000
+pro = 128000
+
+[models."gpt-4.1"]
+model = "gpt-4.1"
+tokenizer = "o200k_base"
+[models."gpt-4.1".budget]
+default = 128000
+free = 16000
+plus = 32000
+pro = 128000
+
+[models."gpt-4.1-mini"]
+model = "gpt-4.1-mini"
+tokenizer = "o200k_base"
+[models."gpt-4.1-mini".budget]
+default = 128000
+free = 16000
+plus = 32000
+pro = 128000

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -10,5 +10,5 @@ def test_build_tree_header_includes_marker(tmp_path):
     builder.record_metadata(rel, 1, 2, 0)
     builder.add_file(file_path, rel, 1, 2, 0, file_path.read_text(encoding="utf-8"))
     lines = builder.build_tree(include_metadata=True)
-    assert lines[0].rstrip().endswith("incl")
-    assert lines[-1].endswith("    ")
+    assert lines[0].rstrip().endswith("included")
+    assert lines[-1].endswith("         ")

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -30,8 +30,8 @@ def test_cli_tokens_summary(monkeypatch, tmp_path):
     )
     main()
     header = captured["lines"][0]
-    assert "tokens" in header and "incl" in header
-    assert header.split() == ["lines", "chars", "tokens", "incl"]
+    assert "tokens" in header and "included" in header
+    assert header.split() == ["lines", "chars", "tokens", "included"]
     assert captured["budget"] == 100
     assert captured["total_tokens"] == 2
     assert captured["tokenizer"] == "o200k_base"
@@ -145,20 +145,12 @@ def test_model_option_sets_tokenizer_and_budget(monkeypatch, tmp_path):
     (tmp_path / "file.txt").write_text("hello world", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
-    class FakeEnc:
-        name = "fake-enc"
-
-    class FakeTok:
-        @staticmethod
-        def encoding_for_model(model):  # noqa: ARG003
-            return FakeEnc
-
-    monkeypatch.setitem(sys.modules, "tiktoken", FakeTok)
     monkeypatch.setattr(
         "grobl.cli.load_tokenizer", lambda name: (lambda text: len(text.split()))
     )
     monkeypatch.setattr(
-        "grobl.cli.MODEL_TOKEN_LIMITS", {"gpt-test": {"default": 32000}}
+        "grobl.cli.MODEL_SPECS",
+        {"gpt-test": {"tokenizer": "fake-enc", "budget": {"default": 32000}}},
     )
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- add bundled model specifications with tokenizers and subscription-tier budgets
- migrate legacy JSON and ignore configs to TOML automatically
- allow configuring default CLI flags via config
- fix summary table header alignment

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_689899bca4288327b47399a590b27216