### PR TITLE
feat: restructure CLI with subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.13] - 2025-08-10
+
+### Added
+- add subcommand-based CLI with default `scan`
+- add global `--version` flag and `version` subcommand
+- add stackable `-v/--verbose` and `--log-level` options
+
+### Changed
+- reorganize CLI around subparsers
+
 ## [0.4.12] - 2025-08-10
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
 # Reimplement CLI – Task Breakdown
-* [ ] Replace single parser with subparsers: `scan` (default), `init`, `config`, `models`, `migrate`, `version`.
+* [x] Replace single parser with subparsers: `scan` (default), `init`, `config`, `models`, `migrate`, `version`.
   * **Done when:** `grobl -h` shows subcommands and `grobl scan` is default when omitted.
-* [ ] Add global `-h/--help` and `-V/--version` available everywhere.
+* [x] Add global `-h/--help` and `-V/--version` available everywhere.
   * **Done when:** `grobl --version` prints version and exits 0.
-* [ ] Implement `-v/--verbose` (stackable) and `--log-level` (advanced).
+* [x] Implement `-v/--verbose` (stackable) and `--log-level` (advanced).
   * **Done when:** `-v` → INFO, `-vv` → DEBUG; `--log-level` overrides.
 * [ ] Implement `--mode [all|tree|summary|files]`.
   * **Done when:** each mode suppresses the others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "grobl"
-  version = "0.4.12"
+  version = "0.4.13"
   description = "A script to display directory structure and Python file contents"
   readme = "README.md"
   authors = [

--- a/src/grobl/__init__.py
+++ b/src/grobl/__init__.py
@@ -1,0 +1,5 @@
+"""Package metadata for grobl."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.4.13"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,7 @@ def test_migrate_config_no_old_files(tmp_path, capsys):
 
 def test_cli_migrate_config(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(sys, "argv", ["grobl", "migrate-config"])
+    monkeypatch.setattr(sys, "argv", ["grobl", "migrate"])
 
     with pytest.raises(SystemExit) as e:
         cli.main()

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -87,7 +87,7 @@ def test_list_token_models(monkeypatch, capsys):
             MODEL_TO_ENCODING = {"m1": "a", "m2": "a", "m3": "b"}
 
     monkeypatch.setitem(sys.modules, "tiktoken", Fake)
-    monkeypatch.setattr(sys, "argv", ["grobl", "--list-token-models"])
+    monkeypatch.setattr(sys, "argv", ["grobl", "models"])
     with pytest.raises(SystemExit) as exc:
         main()
     assert isinstance(exc.value, SystemExit)


### PR DESCRIPTION
## Summary
- refactor CLI to use argparse subcommands with default `scan`
- add global version and logging flags
- expose version constant and bump to 0.4.13

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_689959d152348327a02fea74c65f21c6