### PR TITLE
feat: reimplement CLI with click and add mode/table options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.14] - 2025-08-10
+
+### Added
+- reimplement CLI with click
+- add `--mode` and `--table` options
+
 ## [0.4.13] - 2025-08-10
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@
   * **Done when:** `grobl --version` prints version and exits 0.
 * [x] Implement `-v/--verbose` (stackable) and `--log-level` (advanced).
   * **Done when:** `-v` → INFO, `-vv` → DEBUG; `--log-level` overrides.
-* [ ] Reimplement CLI with click
-* [ ] Implement `--mode [all|tree|summary|files]`.
+* [x] Reimplement CLI with click
+* [x] Implement `--mode [all|tree|summary|files]`.
   * **Done when:** each mode suppresses the others.
-* [ ] Implement `--table [full|compact|none]`.
+* [x] Implement `--table [full|compact|none]`.
   * **Done when:** summary header/columns reflect choice.
 * [ ] Preserve clipboard default; add `--no-clipboard` and `--clipboard-too` (when `--output` is used).
   * **Done when:** combinations behave as specified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "grobl"
-  version = "0.4.13"
+  version = "0.4.14"
   description = "A script to display directory structure and Python file contents"
   readme = "README.md"
   authors = [
@@ -17,9 +17,10 @@
   ]
   requires-python = ">=3.12"
   dependencies = [
+    "click>=8.2.1",
     "pyperclip",
     "tomlkit>=0.13.2",
-  ]
+]
 
   [project.optional-dependencies]
     tokens = ["tiktoken"] # optional dependency for token counting

--- a/src/grobl/__init__.py
+++ b/src/grobl/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"

--- a/src/grobl/formatter.py
+++ b/src/grobl/formatter.py
@@ -18,12 +18,27 @@ def human_summary(
     total_tokens: int | None = None,
     tokenizer: str | None = None,
     budget: int | None = None,
+    table: str = "full",
 ) -> None:
     """Print a human-readable summary table.
 
     ``tokenizer`` is accepted for backwards compatibility but is no longer
     displayed in the summary title.
     """
+
+    if table == "none":
+        return
+
+    if table == "compact":
+        print(f"Total lines: {total_lines}")
+        print(f"Total characters: {total_chars}")
+        if total_tokens is not None:
+            line = f"Total tokens: {total_tokens}"
+            if budget:
+                pct = total_tokens / budget if budget else 0
+                line += f" ({pct:.0%} of {budget:,} token budget)"
+            print(line)
+        return
 
     max_width = max(len(line) for line in tree_lines)
     title = " Project Summary "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,12 +54,7 @@ def test_migrate_config_no_old_files(tmp_path, capsys):
 def test_cli_migrate_config(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "argv", ["grobl", "migrate"])
-
-    with pytest.raises(SystemExit) as e:
-        cli.main()
-    exc = e.value
-    assert isinstance(exc, SystemExit)
-    assert exc.code == 0
+    cli.main()
 
 
 def test_load_json_config(tmp_path):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -17,7 +17,14 @@ def test_cli_tokens_summary(monkeypatch, tmp_path):
     captured: dict[str, object] = {}
 
     def fake_summary(
-        lines, total_lines, total_chars, *, total_tokens, tokenizer, budget
+        lines,
+        total_lines,
+        total_chars,
+        *,
+        total_tokens,
+        tokenizer,
+        budget,
+        table,
     ):
         captured["lines"] = lines
         captured["total_tokens"] = total_tokens
@@ -88,10 +95,7 @@ def test_list_token_models(monkeypatch, capsys):
 
     monkeypatch.setitem(sys.modules, "tiktoken", Fake)
     monkeypatch.setattr(sys, "argv", ["grobl", "models"])
-    with pytest.raises(SystemExit) as exc:
-        main()
-    assert isinstance(exc.value, SystemExit)
-    assert exc.value.code == 0
+    main()
     out = capsys.readouterr().out
     assert "a: m1, m2" in out
     assert "b: m3" in out
@@ -155,7 +159,14 @@ def test_model_option_sets_tokenizer_and_budget(monkeypatch, tmp_path):
     captured: dict[str, object] = {}
 
     def fake_summary(
-        lines, total_lines, total_chars, *, total_tokens, tokenizer, budget
+        lines,
+        total_lines,
+        total_chars,
+        *,
+        total_tokens,
+        tokenizer,
+        budget,
+        table,
     ):
         captured["tokenizer"] = tokenizer
         captured["budget"] = budget


### PR DESCRIPTION
## Summary
- refactor CLI to use click with grouped subcommands
- add `--mode` and `--table` options to control scan output
- support compact/none summary tables

## Testing
- `uv lock`
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995d770324832798e80e2acb0a35c3